### PR TITLE
Update shunting-yard.h

### DIFF
--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -151,8 +151,8 @@ class OppMap_t {
 
 namespace cparse {
 
-class TokenMap;
-class TokenList;
+struct TokenMap;
+struct TokenList;
 class Tuple;
 class STuple;
 class Function;


### PR DESCRIPTION
Fix warning C4099: type name first seen using 'class' now seen using 'struct'